### PR TITLE
feat: Added doc generation and push

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -37,7 +37,7 @@ jobs:
         run: npm ci --prefer-offline
 
       - name: Build Typedoc
-        run: yarn typedoc
+        run: npm run typedoc
 
       - name: Run deploy script
         run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,7 +2,7 @@ name: Deploy to github pages
 on:
   push:
     branches:
-      - feature/docs
+      - main
 
 jobs:
   gh-pages-deploy:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,48 @@
+name: Deploy to github pages
+on:
+  push:
+    branches:
+      - feature/docs
+
+jobs:
+  gh-pages-deploy:
+    name: Deploying to gh-pages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js 16.x for use with actions
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+
+      - name: Cache node modules
+        id: cache-npm
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key:
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{
+            hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline
+
+      - name: Build Typedoc
+        run: yarn typedoc
+
+      - name: Run deploy script
+        run: |
+          git config user.name "github-actions[bot]" 
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git --work-tree docs add --all
+          git --work-tree docs commit -m "gh-pages build"
+          git push origin HEAD:gh-pages --force


### PR DESCRIPTION
Having multiple docs live at once, for different versions, should be possible once this feature gets implemented in typedoc:
https://github.com/TypeStrong/typedoc/issues/1180

And based on this commit, that seems to be in the working:
https://github.com/TypeStrong/typedoc/commit/4008c89f0c6d7a3fe47cb3e7cafda4f426b5ed6d

But for now, showing the main branch should be sufficient.